### PR TITLE
Support for fileuploads from different folders.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -58,7 +58,7 @@ class Sypht{
             await this.authenticate();
             var fileName = path.basename(filePath);
             var fileData = fs.createReadStream(filePath)
-            var isValid = await utils.validateFileType(fileName);
+            var isValid = await utils.validateFileType(filePath);
             if (!isValid) {
                 throw new Error('invalid file : ' + fileName);
             }


### PR DESCRIPTION
I think that using the fileName instead of the full file path in the call to validateFileType method means that an error is thrown if the file being uploaded is in a different folder to the code being run.